### PR TITLE
Split patch file in multiple pieces so we can provide ChatGPT with a larger context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "codereview.gpt",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codereview.gpt",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "buffer": "^6.0.3",
         "chatgpt": "^5.1.3",
         "eventsource-parser": "^0.0.5",
-        "node-html-parser": "^6.1.5"
+        "node-html-parser": "^6.1.5",
+        "parse-diff": "^0.11.1"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^10.2.4",
@@ -3592,6 +3593,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-diff": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
+      "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "buffer": "^6.0.3",
     "chatgpt": "^5.1.3",
     "eventsource-parser": "^0.0.5",
-    "node-html-parser": "^6.1.5"
+    "node-html-parser": "^6.1.5",
+    "parse-diff": "^0.11.1"
   }
 }


### PR DESCRIPTION
We had the problem with large patches that we had to work with a maximum token size of 4096 tokens. 

The following changes were made:

1. Split the patch with the parse-diff library
2. Recompile the patch again with different pieces, and add enough context for ChatGPT to understand the changes
3. Truncate only long patch pieces, instead of the entire patch

This should provide a much more complete code review compared to the previous version.