### PR TITLE
Adding support for Self Hosted GitLab and remove an unnecessary http request as we run scripts on the active tab for detection purposes already

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,15 +18,12 @@
   },
   "permissions": [
     "activeTab",
-    "storage"
+    "storage",
+    "scripting"
   ],
   "options_ui": {
     "page": "options.html",
     "open_in_tab": false
   },
-  "host_permissions": [
-    "https://*.openai.com/",
-    "https://*.githubusercontent.com/",
-    "https://gitlab.com/"
-  ]
+  "host_permissions": ["https://*/*"]
 }


### PR DESCRIPTION
Solves #15 

1. Removes the fetch of the current tab and replaces this with script injection to fetch the required elements. 
  1. For GitLab  this is 
     - a metatag to detect whether the website is GitLab (SaaS or Self-Hosted)
     - the description or the MR. 
  1. For GitHub this is the description of the PR.
1. Adds permissions for the chrome extension to run on all websites, as we do not have a list of self-hosted GitLab instances
1. Fixes error message that did not appear when ran on websites that were not compatible. 
