### PR TITLE
Update project name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ This project is inspired by [clmnin/summarize.site](https://github.com/clmnin/su
 
 ## License
 
-Semantic Code Search is distributed under [MIT](LICENSE.txt).
+codereview.gpt is distributed under [MIT](LICENSE.txt).


### PR DESCRIPTION
This PR updates the Project name under the `## License` section, which appears to have been originally copied from https://github.com/sturdy-dev/semantic-code-search

