### PR TITLE
feat: allow users to give custom base urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codereview.gpt",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codereview.gpt",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "buffer": "^6.0.3",
         "chatgpt": "^5.1.3",

--- a/public/options.html
+++ b/public/options.html
@@ -13,9 +13,15 @@
     </style>
   </head>
   <body>
-    Please store your Open AI API Key here. Fetch one at https://platform.openai.com/account/api-keys.
+    <h2>Open AI API Key</h2>
+    <p>Please store your Open AI API Key. Fetch one at https://platform.openai.com/account/api-keys.</p>
     <input type="password" name="openai_apikey" id="openai_apikey" />
+    <br />
+    <h2>OpenAPI Base URL</h2>
+    <p>Please store your custom OpenAPI Base URL here.</p>
+    <input type="text" name="openai_base_url" id="openai_base_url" value="https://api.openai.com/v1" />
     <div id="status"></div>
+    <br />
     <button id="save">Save</button>
     <script src="options.js"></script>
   </body>

--- a/src/options.js
+++ b/src/options.js
@@ -1,30 +1,32 @@
 // Saves options to chrome.storage
 const saveOptions = () => {
-    const openai_apikey = document.getElementById('openai_apikey').value;
-  
-    chrome.storage.sync.set(
-      { openai_apikey: openai_apikey },
-      () => {
-        // Update status to let user know options were saved.
-        const status = document.getElementById('status');
-        status.textContent = 'Options saved.';
-        setTimeout(() => {
-          status.textContent = '';
-        }, 750);
-      }
-    );
-  };
-  
-  // Restores select box and checkbox state using the preferences
-  // stored in chrome.storage.
-  const restoreOptions = () => {
-    chrome.storage.sync.get(
-      { openai_apikey: '' },
-      (items) => {
-        document.getElementById('openai_apikey').value = items.openai_apikey;
-      }
-    );
-  };
-  
-  document.addEventListener('DOMContentLoaded', restoreOptions);
-  document.getElementById('save').addEventListener('click', saveOptions);
+  const openai_apikey = document.getElementById('openai_apikey').value;
+  const openai_base_url = document.getElementById('openai_base_url').value;
+
+  chrome.storage.sync.set(
+    { openai_apikey: openai_apikey, openai_base_url: openai_base_url },
+    () => {
+      // Update status to let user know options were saved.
+      const status = document.getElementById('status');
+      status.textContent = 'Options saved.';
+      setTimeout(() => {
+        status.textContent = '';
+      }, 750);
+    }
+  );
+};
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+const restoreOptions = () => {
+  chrome.storage.sync.get(
+    { openai_apikey: '', openai_base_url: 'https://api.openai.com/v1' },
+    (items) => {
+      document.getElementById('openai_apikey').value = items.openai_apikey;
+      document.getElementById('openai_base_url').value = items.openai_base_url;
+    }
+  );
+};
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);

--- a/src/popup.js
+++ b/src/popup.js
@@ -52,10 +52,20 @@ async function getApiKey() {
   return options['openai_apikey'];
 }
 
+async function getBaseURL() {
+  let options = await new Promise((resolve) => {
+    chrome.storage.sync.get('openai_base_url', resolve);
+  });
+  console.log(options);
+  return options['openai_base_url'];
+}
+
 async function callChatGPT(messages, callback, onDone) {
   let apiKey;
+  let baseURL;
   try {
     apiKey = await getApiKey();
+    baseURL = await getBaseURL();
   } catch (e) {
     callback('Please add your Open AI API key to the settings of this Chrome Extension.');
     onDone();
@@ -64,6 +74,7 @@ async function callChatGPT(messages, callback, onDone) {
 
   const api = new ChatGPTAPI({
     apiKey: apiKey,
+    apiBaseUrl: baseURL,
     systemMessage: `You are a programming code change reviewer, provide feedback on the code changes given. Do not introduce yourselves.`
   })
 


### PR DESCRIPTION
I typically use GPT using a different base API URL - I am trying to add a change here so the extension can support accepting a different base URL but will use the original one by default. 

Genie, VS Code extensions, also allows you to give a different base url since a lot of companies use a proxy in front of openAI.

I saw that chatgpt npm package supports providing a different custom URL so I have used that here for this purpose.

I am new to the extensions world so if you think something can be done better or this is not going to work, please feel free to leave a comment and I'll try to fix it. 

